### PR TITLE
Fix channel OnClose and OnError event handlers

### DIFF
--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -224,30 +224,15 @@ namespace Supabase.Realtime
                     OnOpen?.Invoke(this, args);
                     break;
                 case SocketStateChangedEventArgs.ConnectionState.Close:
-                    HandleSocketClosed(args);
+                    OnClose?.Invoke(this, args);
                     break;
                 case SocketStateChangedEventArgs.ConnectionState.Error:
-                    HandleSocketError(args);
+                    OnError?.Invoke(this, args);
                     break;
                 case SocketStateChangedEventArgs.ConnectionState.Message:
                     OnMessage?.Invoke(this, args);
                     break;
             }
-        }
-
-        private void HandleSocketClosed(SocketStateChangedEventArgs args)
-        {
-            OnClose?.Invoke(this, null);
-
-            foreach (var kvp in subscriptions)
-                kvp.Value.TriggerChannelClosed(args);
-        }
-
-        private void HandleSocketError(SocketStateChangedEventArgs args)
-        {
-            OnError?.Invoke(this, null);
-            foreach (var kvp in subscriptions)
-                kvp.Value.TriggerChannelErrored(args);
         }
     }
 }

--- a/RealtimeExample/Program.cs
+++ b/RealtimeExample/Program.cs
@@ -22,12 +22,24 @@ namespace RealtimeExample
             await realtimeClient.Connect();
 
             // Subscribe to a channel and events
-            var channel = realtimeClient.Channel("realtime", "public", "users");
-            channel.OnInsert += (object s, SocketResponseEventArgs args) => Console.WriteLine("New item inserted: " + args.Response.Payload.Record);
-            channel.OnUpdate += (object s, SocketResponseEventArgs args) => Console.WriteLine("Item updated: " + args.Response.Payload.Record);
-            channel.OnDelete += (object s, SocketResponseEventArgs args) => Console.WriteLine("Item deleted");
+            var channelUsers = realtimeClient.Channel("realtime", "public", "users");
+            channelUsers.OnInsert += (object s, SocketResponseEventArgs args) => Console.WriteLine("New item inserted: " + args.Response.Payload.Record);
+            channelUsers.OnUpdate += (object s, SocketResponseEventArgs args) => Console.WriteLine("Item updated: " + args.Response.Payload.Record);
+            channelUsers.OnDelete += (object s, SocketResponseEventArgs args) => Console.WriteLine("Item deleted");
 
-            await channel.Subscribe();
+            Console.WriteLine("Subscribing to users channel");
+            await channelUsers.Subscribe();
+
+            //Subscribing to another channel
+            var channelTodos = realtimeClient.Channel("realtime", "public", "todos");
+            channelTodos.OnClose += (object sender, ChannelStateChangedEventArgs args) => Console.WriteLine($"Channel todos { args.State}!!");
+            Console.WriteLine("Subscribing to todos channel");
+            await channelTodos.Subscribe();
+
+            //Unsubscribing from channelTodos to trigger the OnClose event
+            channelTodos.Unsubscribe();
+
+            Console.WriteLine($"Users channel state after unsubscribing from todos channel: {channelUsers.State}");
 
             var response = await postgrestClient.Table<User>().Insert(new User { Name = "exampleUser" });
             var user = response.Models.FirstOrDefault();

--- a/RealtimeTests/API.cs
+++ b/RealtimeTests/API.cs
@@ -225,5 +225,17 @@ namespace RealtimeTests
             await RestClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives wildcard callbacks? ✅" });
 
         }
+
+        [TestMethod("Channel: Close Event Handler")]
+        public async Task ChannelCloseEventHandler()
+        {
+            var channel = SocketClient.Channel("realtime", "public", "todos");
+            channel.OnClose += (object sender, ChannelStateChangedEventArgs args) =>
+            {
+                Assert.AreEqual(ChannelState.Closed, args.State);
+            };
+            await channel.Subscribe();
+            channel.Unsubscribe();
+        }
     }
 }


### PR DESCRIPTION
Hello, @acupofjose if you can review this please.

## What kind of change does this PR introduce?
Bug fix
## What is the current behavior?

Please correct me if I'm wrong I'm still figuring it out

* We are returning a SocketStateChangedEventArgs I think we should return a ChannelStateChangedEventArgs since the channel state that changed not the Socket
* In the client there is two methods HandleSocketClosed and HandleSocketError that trigger foreach subscription the OnClose or OnError event I think we can close only one channel or an error can occure only on one channel

## What is the new behavior?

* Returning ChannelStateChangedEventArgs instead of SocketStateChangedEventArgs
* Trigger OnClose event if the client unsubscribe to this channel

Thank you.
